### PR TITLE
use long options

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ before_install:
   - image="gradle:${VERSION}${VARIANT:+-$VARIANT}"
 
 install:
-  - docker build -t "${image}" .
+  - docker build --tag "${image}" .
 
 script:
   - cd ../test

--- a/jdk7-alpine/Dockerfile
+++ b/jdk7-alpine/Dockerfile
@@ -10,7 +10,7 @@ VOLUME "/root/.gradle"
 
 ENV GRADLE_VERSION 3.4
 ARG GRADLE_DOWNLOAD_SHA256=72d0cd4dcdd5e3be165eb7cd7bbd25cf8968baf400323d9ab1bba622c3f72205
-RUN set -eu \
+RUN set -o errexit -o nounset \
 	&& echo "Installing dependencies" \
 	&& apk add --no-cache \
 		bash \

--- a/jdk7/Dockerfile
+++ b/jdk7/Dockerfile
@@ -10,12 +10,12 @@ VOLUME "/root/.gradle"
 
 ENV GRADLE_VERSION 3.4
 ARG GRADLE_DOWNLOAD_SHA256=72d0cd4dcdd5e3be165eb7cd7bbd25cf8968baf400323d9ab1bba622c3f72205
-RUN set -eu \
+RUN set -o errexit -o nounset \
 	&& echo "Downloading Gradle" \
-	&& wget -nv -O gradle.zip "https://services.gradle.org/distributions/gradle-${GRADLE_VERSION}-bin.zip" \
+	&& wget --no-verbose --output-document=gradle.zip "https://services.gradle.org/distributions/gradle-${GRADLE_VERSION}-bin.zip" \
 	\
 	&& echo "Checking download hash" \
-	&& echo "${GRADLE_DOWNLOAD_SHA256} *gradle.zip" | sha256sum -c - \
+	&& echo "${GRADLE_DOWNLOAD_SHA256} *gradle.zip" | sha256sum --check - \
 	\
 	&& echo "Installing Gradle" \
 	&& unzip gradle.zip \

--- a/jdk8-alpine/Dockerfile
+++ b/jdk8-alpine/Dockerfile
@@ -10,7 +10,7 @@ VOLUME "/root/.gradle"
 
 ENV GRADLE_VERSION 3.4
 ARG GRADLE_DOWNLOAD_SHA256=72d0cd4dcdd5e3be165eb7cd7bbd25cf8968baf400323d9ab1bba622c3f72205
-RUN set -eu \
+RUN set -o errexit -o nounset \
 	&& echo "Installing dependencies" \
 	&& apk add --no-cache \
 		bash \

--- a/jdk8/Dockerfile
+++ b/jdk8/Dockerfile
@@ -10,12 +10,12 @@ VOLUME "/root/.gradle"
 
 ENV GRADLE_VERSION 3.4
 ARG GRADLE_DOWNLOAD_SHA256=72d0cd4dcdd5e3be165eb7cd7bbd25cf8968baf400323d9ab1bba622c3f72205
-RUN set -eu \
+RUN set -o errexit -o nounset \
 	&& echo "Downloading Gradle" \
-	&& wget -nv -O gradle.zip "https://services.gradle.org/distributions/gradle-${GRADLE_VERSION}-bin.zip" \
+	&& wget --no-verbose --output-document=gradle.zip "https://services.gradle.org/distributions/gradle-${GRADLE_VERSION}-bin.zip" \
 	\
 	&& echo "Checking download hash" \
-	&& echo "${GRADLE_DOWNLOAD_SHA256} *gradle.zip" | sha256sum -c - \
+	&& echo "${GRADLE_DOWNLOAD_SHA256} *gradle.zip" | sha256sum --check - \
 	\
 	&& echo "Installing Gradle" \
 	&& unzip gradle.zip \

--- a/jdk9/Dockerfile
+++ b/jdk9/Dockerfile
@@ -10,12 +10,12 @@ VOLUME "/root/.gradle"
 
 ENV GRADLE_VERSION 3.4
 ARG GRADLE_DOWNLOAD_SHA256=72d0cd4dcdd5e3be165eb7cd7bbd25cf8968baf400323d9ab1bba622c3f72205
-RUN set -eu \
+RUN set -o errexit -o nounset \
 	&& echo "Downloading Gradle" \
-	&& wget -nv -O gradle.zip "https://services.gradle.org/distributions/gradle-${GRADLE_VERSION}-bin.zip" \
+	&& wget --no-verbose --output-document=gradle.zip "https://services.gradle.org/distributions/gradle-${GRADLE_VERSION}-bin.zip" \
 	\
 	&& echo "Checking download hash" \
-	&& echo "${GRADLE_DOWNLOAD_SHA256} *gradle.zip" | sha256sum -c - \
+	&& echo "${GRADLE_DOWNLOAD_SHA256} *gradle.zip" | sha256sum --check - \
 	\
 	&& echo "Installing Gradle" \
 	&& unzip gradle.zip \

--- a/jre7-alpine/Dockerfile
+++ b/jre7-alpine/Dockerfile
@@ -10,7 +10,7 @@ VOLUME "/root/.gradle"
 
 ENV GRADLE_VERSION 3.4
 ARG GRADLE_DOWNLOAD_SHA256=72d0cd4dcdd5e3be165eb7cd7bbd25cf8968baf400323d9ab1bba622c3f72205
-RUN set -eu \
+RUN set -o errexit -o nounset \
 	&& echo "Installing dependencies" \
 	&& apk add --no-cache \
 		bash \

--- a/jre7/Dockerfile
+++ b/jre7/Dockerfile
@@ -10,12 +10,12 @@ VOLUME "/root/.gradle"
 
 ENV GRADLE_VERSION 3.4
 ARG GRADLE_DOWNLOAD_SHA256=72d0cd4dcdd5e3be165eb7cd7bbd25cf8968baf400323d9ab1bba622c3f72205
-RUN set -eu \
+RUN set -o errexit -o nounset \
 	&& echo "Downloading Gradle" \
-	&& wget -nv -O gradle.zip "https://services.gradle.org/distributions/gradle-${GRADLE_VERSION}-bin.zip" \
+	&& wget --no-verbose --output-document=gradle.zip "https://services.gradle.org/distributions/gradle-${GRADLE_VERSION}-bin.zip" \
 	\
 	&& echo "Checking download hash" \
-	&& echo "${GRADLE_DOWNLOAD_SHA256} *gradle.zip" | sha256sum -c - \
+	&& echo "${GRADLE_DOWNLOAD_SHA256} *gradle.zip" | sha256sum --check - \
 	\
 	&& echo "Installing Gradle" \
 	&& unzip gradle.zip \

--- a/jre8-alpine/Dockerfile
+++ b/jre8-alpine/Dockerfile
@@ -10,7 +10,7 @@ VOLUME "/root/.gradle"
 
 ENV GRADLE_VERSION 3.4
 ARG GRADLE_DOWNLOAD_SHA256=72d0cd4dcdd5e3be165eb7cd7bbd25cf8968baf400323d9ab1bba622c3f72205
-RUN set -eu \
+RUN set -o errexit -o nounset \
 	&& echo "Installing dependencies" \
 	&& apk add --no-cache \
 		bash \

--- a/jre8/Dockerfile
+++ b/jre8/Dockerfile
@@ -10,12 +10,12 @@ VOLUME "/root/.gradle"
 
 ENV GRADLE_VERSION 3.4
 ARG GRADLE_DOWNLOAD_SHA256=72d0cd4dcdd5e3be165eb7cd7bbd25cf8968baf400323d9ab1bba622c3f72205
-RUN set -eu \
+RUN set -o errexit -o nounset \
 	&& echo "Downloading Gradle" \
-	&& wget -nv -O gradle.zip "https://services.gradle.org/distributions/gradle-${GRADLE_VERSION}-bin.zip" \
+	&& wget --no-verbose --output-document=gradle.zip "https://services.gradle.org/distributions/gradle-${GRADLE_VERSION}-bin.zip" \
 	\
 	&& echo "Checking download hash" \
-	&& echo "${GRADLE_DOWNLOAD_SHA256} *gradle.zip" | sha256sum -c - \
+	&& echo "${GRADLE_DOWNLOAD_SHA256} *gradle.zip" | sha256sum --check - \
 	\
 	&& echo "Installing Gradle" \
 	&& unzip gradle.zip \

--- a/jre9/Dockerfile
+++ b/jre9/Dockerfile
@@ -10,12 +10,12 @@ VOLUME "/root/.gradle"
 
 ENV GRADLE_VERSION 3.4
 ARG GRADLE_DOWNLOAD_SHA256=72d0cd4dcdd5e3be165eb7cd7bbd25cf8968baf400323d9ab1bba622c3f72205
-RUN set -eu \
+RUN set -o errexit -o nounset \
 	&& echo "Downloading Gradle" \
-	&& wget -nv -O gradle.zip "https://services.gradle.org/distributions/gradle-${GRADLE_VERSION}-bin.zip" \
+	&& wget --no-verbose --output-document=gradle.zip "https://services.gradle.org/distributions/gradle-${GRADLE_VERSION}-bin.zip" \
 	\
 	&& echo "Checking download hash" \
-	&& echo "${GRADLE_DOWNLOAD_SHA256} *gradle.zip" | sha256sum -c - \
+	&& echo "${GRADLE_DOWNLOAD_SHA256} *gradle.zip" | sha256sum --check - \
 	\
 	&& echo "Installing Gradle" \
 	&& unzip gradle.zip \

--- a/test/run.sh
+++ b/test/run.sh
@@ -1,17 +1,17 @@
 #!/usr/bin/env bash
-set -eu
+set -o errexit -o nounset
 
 image=$1
 expectedGradleVersion=$2
 
-version=$(docker run --rm "${image}" gradle --version | grep -E "Gradle [0-9.]+" | grep -Eo "[0-9.]+")
+version=$(docker run --rm "${image}" gradle --version | grep  --extended-regexp "Gradle [0-9.]+" | grep  --extended-regexp --only-matching "[0-9.]+")
 if [ "${version}" != "${expectedGradleVersion}" ]; then
     echo "version '${version}' does not match expected version '${expectedGradleVersion}'"
     exit 1
 fi
 
 if [ $(echo "${image}" | grep 'jre') = "" ]; then
-    if [ "$(docker run --rm -v "${PWD}/java-quickstart:/project" -w "/project" "${image}" gradle clean test | grep 'BUILD SUCCESSFUL')" = "" ]; then
+    if [ "$(docker run --rm --volume "${PWD}/java-quickstart:/project" --workdir "/project" "${image}" gradle clean test | grep 'BUILD SUCCESSFUL')" = "" ]; then
         echo "java-quickstart test failed"
         exit 1
     fi


### PR DESCRIPTION
Using long options is more readable than short options. Short options are good for running interactive commands, but long options are better for scripts.  Busybox on Alpine doesn't seem to support long options, so those are unchanged.