### PR TITLE
Remove Git PPA

### DIFF
--- a/hotspot/jdk11/Dockerfile
+++ b/hotspot/jdk11/Dockerfile
@@ -19,15 +19,6 @@ VOLUME /home/gradle/.gradle
 WORKDIR /home/gradle
 
 RUN apt-get update \
-    && apt-get install --yes --no-install-recommends gnupg \
-    && key='E1DD270288B4E6030699E45FA1715D88E1DF1F24' \
-    && export GNUPGHOME="$(mktemp -d)" \
-    && gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys "$key" \
-    && gpg --batch --armor --export "$key" > /etc/apt/trusted.gpg.d/git-ppa.gpg.asc \
-    && gpgconf --kill all \
-    && rm -rf "$GNUPGHOME" \
-    && echo 'deb http://ppa.launchpad.net/git-core/ppa/ubuntu bionic main' > /etc/apt/sources.list.d/git-core-ppa.list \
-    && apt-get update \
     && apt-get install --yes --no-install-recommends \
         fontconfig \
         unzip \

--- a/hotspot/jdk15/Dockerfile
+++ b/hotspot/jdk15/Dockerfile
@@ -19,15 +19,6 @@ VOLUME /home/gradle/.gradle
 WORKDIR /home/gradle
 
 RUN apt-get update \
-    && apt-get install --yes --no-install-recommends gnupg \
-    && key='E1DD270288B4E6030699E45FA1715D88E1DF1F24' \
-    && export GNUPGHOME="$(mktemp -d)" \
-    && gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys "$key" \
-    && gpg --batch --armor --export "$key" > /etc/apt/trusted.gpg.d/git-ppa.gpg.asc \
-    && gpgconf --kill all \
-    && rm -rf "$GNUPGHOME" \
-    && echo 'deb http://ppa.launchpad.net/git-core/ppa/ubuntu bionic main' > /etc/apt/sources.list.d/git-core-ppa.list \
-    && apt-get update \
     && apt-get install --yes --no-install-recommends \
         fontconfig \
         unzip \

--- a/hotspot/jdk8/Dockerfile
+++ b/hotspot/jdk8/Dockerfile
@@ -19,15 +19,6 @@ VOLUME /home/gradle/.gradle
 WORKDIR /home/gradle
 
 RUN apt-get update \
-    && apt-get install --yes --no-install-recommends gnupg \
-    && key='E1DD270288B4E6030699E45FA1715D88E1DF1F24' \
-    && export GNUPGHOME="$(mktemp -d)" \
-    && gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys "$key" \
-    && gpg --batch --armor --export "$key" > /etc/apt/trusted.gpg.d/git-ppa.gpg.asc \
-    && gpgconf --kill all \
-    && rm -rf "$GNUPGHOME" \
-    && echo 'deb http://ppa.launchpad.net/git-core/ppa/ubuntu bionic main' > /etc/apt/sources.list.d/git-core-ppa.list \
-    && apt-get update \
     && apt-get install --yes --no-install-recommends \
         fontconfig \
         unzip \

--- a/hotspot/jre11/Dockerfile
+++ b/hotspot/jre11/Dockerfile
@@ -19,15 +19,6 @@ VOLUME /home/gradle/.gradle
 WORKDIR /home/gradle
 
 RUN apt-get update \
-    && apt-get install --yes --no-install-recommends gnupg \
-    && key='E1DD270288B4E6030699E45FA1715D88E1DF1F24' \
-    && export GNUPGHOME="$(mktemp -d)" \
-    && gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys "$key" \
-    && gpg --batch --armor --export "$key" > /etc/apt/trusted.gpg.d/git-ppa.gpg.asc \
-    && gpgconf --kill all \
-    && rm -rf "$GNUPGHOME" \
-    && echo 'deb http://ppa.launchpad.net/git-core/ppa/ubuntu bionic main' > /etc/apt/sources.list.d/git-core-ppa.list \
-    && apt-get update \
     && apt-get install --yes --no-install-recommends \
         fontconfig \
         unzip \

--- a/hotspot/jre15/Dockerfile
+++ b/hotspot/jre15/Dockerfile
@@ -19,15 +19,6 @@ VOLUME /home/gradle/.gradle
 WORKDIR /home/gradle
 
 RUN apt-get update \
-    && apt-get install --yes --no-install-recommends gnupg \
-    && key='E1DD270288B4E6030699E45FA1715D88E1DF1F24' \
-    && export GNUPGHOME="$(mktemp -d)" \
-    && gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys "$key" \
-    && gpg --batch --armor --export "$key" > /etc/apt/trusted.gpg.d/git-ppa.gpg.asc \
-    && gpgconf --kill all \
-    && rm -rf "$GNUPGHOME" \
-    && echo 'deb http://ppa.launchpad.net/git-core/ppa/ubuntu bionic main' > /etc/apt/sources.list.d/git-core-ppa.list \
-    && apt-get update \
     && apt-get install --yes --no-install-recommends \
         fontconfig \
         unzip \

--- a/hotspot/jre8/Dockerfile
+++ b/hotspot/jre8/Dockerfile
@@ -19,15 +19,6 @@ VOLUME /home/gradle/.gradle
 WORKDIR /home/gradle
 
 RUN apt-get update \
-    && apt-get install --yes --no-install-recommends gnupg \
-    && key='E1DD270288B4E6030699E45FA1715D88E1DF1F24' \
-    && export GNUPGHOME="$(mktemp -d)" \
-    && gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys "$key" \
-    && gpg --batch --armor --export "$key" > /etc/apt/trusted.gpg.d/git-ppa.gpg.asc \
-    && gpgconf --kill all \
-    && rm -rf "$GNUPGHOME" \
-    && echo 'deb http://ppa.launchpad.net/git-core/ppa/ubuntu bionic main' > /etc/apt/sources.list.d/git-core-ppa.list \
-    && apt-get update \
     && apt-get install --yes --no-install-recommends \
         fontconfig \
         unzip \

--- a/openj9/jdk11/Dockerfile
+++ b/openj9/jdk11/Dockerfile
@@ -19,15 +19,6 @@ VOLUME /home/gradle/.gradle
 WORKDIR /home/gradle
 
 RUN apt-get update \
-    && apt-get install --yes --no-install-recommends gnupg \
-    && key='E1DD270288B4E6030699E45FA1715D88E1DF1F24' \
-    && export GNUPGHOME="$(mktemp -d)" \
-    && gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys "$key" \
-    && gpg --batch --armor --export "$key" > /etc/apt/trusted.gpg.d/git-ppa.gpg.asc \
-    && gpgconf --kill all \
-    && rm -rf "$GNUPGHOME" \
-    && echo 'deb http://ppa.launchpad.net/git-core/ppa/ubuntu bionic main' > /etc/apt/sources.list.d/git-core-ppa.list \
-    && apt-get update \
     && apt-get install --yes --no-install-recommends \
         fontconfig \
         unzip \

--- a/openj9/jdk15/Dockerfile
+++ b/openj9/jdk15/Dockerfile
@@ -19,15 +19,6 @@ VOLUME /home/gradle/.gradle
 WORKDIR /home/gradle
 
 RUN apt-get update \
-    && apt-get install --yes --no-install-recommends gnupg \
-    && key='E1DD270288B4E6030699E45FA1715D88E1DF1F24' \
-    && export GNUPGHOME="$(mktemp -d)" \
-    && gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys "$key" \
-    && gpg --batch --armor --export "$key" > /etc/apt/trusted.gpg.d/git-ppa.gpg.asc \
-    && gpgconf --kill all \
-    && rm -rf "$GNUPGHOME" \
-    && echo 'deb http://ppa.launchpad.net/git-core/ppa/ubuntu bionic main' > /etc/apt/sources.list.d/git-core-ppa.list \
-    && apt-get update \
     && apt-get install --yes --no-install-recommends \
         fontconfig \
         unzip \

--- a/openj9/jdk8/Dockerfile
+++ b/openj9/jdk8/Dockerfile
@@ -19,15 +19,6 @@ VOLUME /home/gradle/.gradle
 WORKDIR /home/gradle
 
 RUN apt-get update \
-    && apt-get install --yes --no-install-recommends gnupg \
-    && key='E1DD270288B4E6030699E45FA1715D88E1DF1F24' \
-    && export GNUPGHOME="$(mktemp -d)" \
-    && gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys "$key" \
-    && gpg --batch --armor --export "$key" > /etc/apt/trusted.gpg.d/git-ppa.gpg.asc \
-    && gpgconf --kill all \
-    && rm -rf "$GNUPGHOME" \
-    && echo 'deb http://ppa.launchpad.net/git-core/ppa/ubuntu bionic main' > /etc/apt/sources.list.d/git-core-ppa.list \
-    && apt-get update \
     && apt-get install --yes --no-install-recommends \
         fontconfig \
         unzip \

--- a/openj9/jre11/Dockerfile
+++ b/openj9/jre11/Dockerfile
@@ -19,15 +19,6 @@ VOLUME /home/gradle/.gradle
 WORKDIR /home/gradle
 
 RUN apt-get update \
-    && apt-get install --yes --no-install-recommends gnupg \
-    && key='E1DD270288B4E6030699E45FA1715D88E1DF1F24' \
-    && export GNUPGHOME="$(mktemp -d)" \
-    && gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys "$key" \
-    && gpg --batch --armor --export "$key" > /etc/apt/trusted.gpg.d/git-ppa.gpg.asc \
-    && gpgconf --kill all \
-    && rm -rf "$GNUPGHOME" \
-    && echo 'deb http://ppa.launchpad.net/git-core/ppa/ubuntu bionic main' > /etc/apt/sources.list.d/git-core-ppa.list \
-    && apt-get update \
     && apt-get install --yes --no-install-recommends \
         fontconfig \
         unzip \

--- a/openj9/jre15/Dockerfile
+++ b/openj9/jre15/Dockerfile
@@ -19,15 +19,6 @@ VOLUME /home/gradle/.gradle
 WORKDIR /home/gradle
 
 RUN apt-get update \
-    && apt-get install --yes --no-install-recommends gnupg \
-    && key='E1DD270288B4E6030699E45FA1715D88E1DF1F24' \
-    && export GNUPGHOME="$(mktemp -d)" \
-    && gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys "$key" \
-    && gpg --batch --armor --export "$key" > /etc/apt/trusted.gpg.d/git-ppa.gpg.asc \
-    && gpgconf --kill all \
-    && rm -rf "$GNUPGHOME" \
-    && echo 'deb http://ppa.launchpad.net/git-core/ppa/ubuntu bionic main' > /etc/apt/sources.list.d/git-core-ppa.list \
-    && apt-get update \
     && apt-get install --yes --no-install-recommends \
         fontconfig \
         unzip \

--- a/openj9/jre8/Dockerfile
+++ b/openj9/jre8/Dockerfile
@@ -19,15 +19,6 @@ VOLUME /home/gradle/.gradle
 WORKDIR /home/gradle
 
 RUN apt-get update \
-    && apt-get install --yes --no-install-recommends gnupg \
-    && key='E1DD270288B4E6030699E45FA1715D88E1DF1F24' \
-    && export GNUPGHOME="$(mktemp -d)" \
-    && gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys "$key" \
-    && gpg --batch --armor --export "$key" > /etc/apt/trusted.gpg.d/git-ppa.gpg.asc \
-    && gpgconf --kill all \
-    && rm -rf "$GNUPGHOME" \
-    && echo 'deb http://ppa.launchpad.net/git-core/ppa/ubuntu bionic main' > /etc/apt/sources.list.d/git-core-ppa.list \
-    && apt-get update \
     && apt-get install --yes --no-install-recommends \
         fontconfig \
         unzip \


### PR DESCRIPTION
Current version in Focal repo: 2.25.1
PPA version: 2.29.0

Now that adoptopenjdk upstream image is based on Focal, the Git provided by the repo should new enough that we don't need the PPA anymore.