### PR TITLE
Re-enable Java 15 OpenJ19

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,10 +14,6 @@ jobs:
         jvm: [hotspot, openj9]
         jvmType: [jdk, jre]
         version: [8, 11, 15]
-        exclude:
-          # temporarily skip OpenJ9 Java 15 due to an OpenJ9 bug
-          - jvm: openj9
-            version: 15
     steps:
       - name: checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
It was my understanding the Openj9 [bug](https://github.com/eclipse/openj9/issues/11013) has been fixed.

Edit: It looks like this hasn't been released in AdoptOpenJDK [yet](https://adoptopenjdk.net/releases.html?variant=openjdk15&jvmVariant=openj9), which will need to happen before the [upstream image](https://github.com/AdoptOpenJDK/openjdk-docker) will have the fix.