### PR TITLE
Add images with both Java 17 and 21

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: [jdk11, jdk11-alpine, jdk11-focal, jdk17, jdk17-alpine, jdk17-focal, jdk17-graal, jdk17-focal-graal, jdk21, jdk21-alpine, jdk21-graal]
+        version: [jdk11, jdk11-alpine, jdk11-focal, jdk17, jdk17-alpine, jdk17-focal, jdk17-graal, jdk17-focal-graal, jdk21, jdk21-alpine, jdk21-graal, jdk17and21, jdk17and21-alpine, jdk17and21-graal]
     steps:
       - name: checkout
         uses: actions/checkout@v2
@@ -26,8 +26,7 @@ jobs:
           version: ${{ matrix.version }}
         run: |
           cd "${version}"
-          baseImage=$(grep "FROM " Dockerfile | cut -d' ' -f2)
-          docker pull "${baseImage}"
+          grep "FROM " Dockerfile | cut -d' ' -f2 | xargs -I{} docker pull {}
           docker build --tag "gradle:${version}" .
       - name: test
         env:

--- a/jdk17and21-alpine/Dockerfile
+++ b/jdk17and21-alpine/Dockerfile
@@ -1,0 +1,69 @@
+FROM eclipse-temurin:21-jdk-alpine AS java21
+
+FROM eclipse-temurin:17-jdk-alpine
+
+COPY --from=java21 /opt/java/openjdk /opt/java/openjdk21
+RUN set -o errexit -o nounset \
+    && ln -s /opt/java/openjdk17 /opt/java/openjdk
+ENV JAVA17_HOME /opt/java/openjdk17
+ENV JAVA21_HOME /opt/java/openjdk21
+
+CMD ["gradle"]
+
+ENV GRADLE_HOME /opt/gradle
+
+RUN set -o errexit -o nounset \
+    && echo "Adding gradle user and group" \
+    && addgroup --system --gid 1000 gradle \
+    && adduser --system --ingroup gradle --uid 1000 --shell /bin/ash gradle \
+    && mkdir /home/gradle/.gradle \
+    && chown -R gradle:gradle /home/gradle \
+    \
+    && echo "Symlinking root Gradle cache to gradle Gradle cache" \
+    && ln -s /home/gradle/.gradle /root/.gradle \
+   \
+   && echo "Ensuring Gradle uses Java 21" \
+   && echo "org.gradle.java.installations.auto-detect=false" > /home/gradle/.gradle/gradle.properties \
+   && echo "org.gradle.java.installations.auto-download=false" >> /home/gradle/.gradle/gradle.properties \
+   && echo "org.gradle.java.installations.fromEnv=JAVA21_HOME" >> /home/gradle/.gradle/gradle.properties
+
+VOLUME /home/gradle/.gradle
+
+WORKDIR /home/gradle
+
+RUN set -o errexit -o nounset \
+    && echo "Installing VCSes" \
+    && apk add --no-cache \
+      git \
+      git-lfs \
+      mercurial \
+      subversion \
+    \
+    && echo "Testing VCSes" \
+    && which git \
+    && which git-lfs \
+    && which hg \
+    && which svn
+
+ENV GRADLE_VERSION 8.4
+ARG GRADLE_DOWNLOAD_SHA256=3e1af3ae886920c3ac87f7a91f816c0c7c436f276a6eefdb3da152100fef72ae
+RUN set -o errexit -o nounset \
+    && echo "Downloading Gradle" \
+    && wget --no-verbose --output-document=gradle.zip "https://services.gradle.org/distributions/gradle-${GRADLE_VERSION}-bin.zip" \
+    \
+    && echo "Checking Gradle download hash" \
+    && echo "${GRADLE_DOWNLOAD_SHA256} *gradle.zip" | sha256sum -c - \
+    \
+    && echo "Installing Gradle" \
+    && unzip gradle.zip \
+    && rm gradle.zip \
+    && mv "gradle-${GRADLE_VERSION}" "${GRADLE_HOME}/" \
+    && ln -s "${GRADLE_HOME}/bin/gradle" /usr/bin/gradle
+
+USER gradle
+
+RUN set -o errexit -o nounset \
+    && echo "Testing Gradle installation" \
+    && gradle --version
+
+USER root

--- a/jdk17and21-graal/Dockerfile
+++ b/jdk17and21-graal/Dockerfile
@@ -1,0 +1,131 @@
+FROM ubuntu:jammy
+
+CMD ["gradle"]
+
+ENV GRADLE_HOME /opt/gradle
+
+RUN set -o errexit -o nounset \
+    && echo "Adding gradle user and group" \
+    && groupadd --system --gid 1000 gradle \
+    && useradd --system --gid gradle --uid 1000 --shell /bin/bash --create-home gradle \
+    && mkdir /home/gradle/.gradle \
+    \
+    && echo "Symlinking root Gradle cache to gradle Gradle cache" \
+    && ln --symbolic /home/gradle/.gradle /root/.gradle \
+   \
+   && echo "Ensuring Gradle uses Java 20" \
+   && echo "org.gradle.java.installations.auto-detect=false" > /home/gradle/.gradle/gradle.properties \
+   && echo "org.gradle.java.installations.auto-download=false" >> /home/gradle/.gradle/gradle.properties \
+   && echo "org.gradle.java.installations.fromEnv=JAVA20_HOME" >> /home/gradle/.gradle/gradle.properties
+
+VOLUME /home/gradle/.gradle
+
+WORKDIR /home/gradle
+
+RUN set -o errexit -o nounset \
+    && export DEBIAN_FRONTEND=noninteractive \
+    && apt-get update \
+    && apt-get install --yes --no-install-recommends \
+        binutils \
+        ca-certificates \
+        curl \
+        fontconfig \
+        locales \
+        p11-kit \
+        tzdata \
+        unzip \
+        wget \
+        \
+        gcc \
+        libc-dev \
+        libz-dev \
+        zlib1g-dev \
+        \
+        bzr \
+        git \
+        git-lfs \
+        mercurial \
+        openssh-client \
+        subversion \
+    && rm --recursive --force /var/lib/apt/lists/* \
+    \
+    && echo "Testing VCSes" \
+    && which bzr \
+    && which git \
+    && which git-lfs \
+    && which hg \
+    && which svn
+
+ENV JAVA_HOME=/opt/java/graalvm
+ENV JAVA17_HOME /opt/java/graalvm17
+ENV JAVA20_HOME /opt/java/graalvm20
+RUN set -o errexit -o nounset \
+    && mkdir /opt/java \
+    \
+    && echo "Downloading GraalVM 17" \
+    && JDK_VERSION=17.0.8 \
+    && GRAALVM_DOWNLOAD_SHA256=1dffdf5c7cc5bf38558e9f093eef6a14072a6dff0be3a9906208b37b53ecc009 \
+    && ARCHITECTURE=$(dpkg --print-architecture) \
+    && if [ "${ARCHITECTURE}" = "amd64" ]; then GRAALVM_ARCHITECTURE=linux-x64; fi \
+    && if [ "${ARCHITECTURE}" = "arm64" ]; then GRAALVM_ARCHITECTURE=linux-aarch64; fi \
+    && GRAALVM_PKG=https://github.com/graalvm/graalvm-ce-builds/releases/download/jdk-${JDK_VERSION}/graalvm-community-jdk-${JDK_VERSION}_${GRAALVM_ARCHITECTURE}_bin.tar.gz \
+    && wget --no-verbose --output-document=graalvm.tar.gz "${GRAALVM_PKG}" \
+    \
+    && echo "Checking GraalVM 17 download hash" \
+    && echo "${GRAALVM_DOWNLOAD_SHA256} *graalvm.tar.gz" | sha256sum --check - \
+    \
+    && echo "Installing GraalVM 17" \
+    && tar --extract --gunzip --file graalvm.tar.gz \
+    && rm graalvm.tar.gz \
+    && mv graalvm-* /opt/java/graalvm17 \
+    \
+    && echo "Downloading GraalVM 21" \
+    && JDK_VERSION=21.0.0 \
+    && GRAALVM_DOWNLOAD_SHA256=6c422941ccc58be5b891bb6499feeb72cd2b74d6729a29bf1fb8cc1a7d58b319 \
+    && ARCHITECTURE=$(dpkg --print-architecture) \
+    && if [ "${ARCHITECTURE}" = "amd64" ]; then GRAALVM_ARCHITECTURE=linux-x64; fi \
+    && if [ "${ARCHITECTURE}" = "arm64" ]; then GRAALVM_ARCHITECTURE=linux-aarch64; fi \
+    && GRAALVM_PKG=https://github.com/graalvm/graalvm-ce-builds/releases/download/jdk-${JDK_VERSION}/graalvm-community-jdk-${JDK_VERSION}_${GRAALVM_ARCHITECTURE}_bin.tar.gz \
+    && wget --no-verbose --output-document=graalvm.tar.gz "${GRAALVM_PKG}" \
+    \
+    && echo "Checking GraalVM 20 download hash" \
+    && echo "${GRAALVM_DOWNLOAD_SHA256} *graalvm.tar.gz" | sha256sum --check - \
+    \
+    && echo "Installing GraalVM 20" \
+    && tar --extract --gunzip --file graalvm.tar.gz \
+    && rm graalvm.tar.gz \
+    && mv graalvm-* /opt/java/graalvm20 \
+    \
+    && echo "Default Java to GraalVM 20" \
+    && ln --symbolic /opt/java/graalvm20 /opt/java/graalvm \
+    && for bin in /opt/java/graalvm20/bin/*; do \
+        base="$(basename "$bin")"; \
+        [ ! -e "/usr/bin/$base" ]; \
+        update-alternatives --install "/usr/bin/${base}" "${base}" "${bin}" 1; \
+    done \
+    \
+    && echo "Testing GraalVM installation" \
+    && java --version \
+    && javac --version \
+    && native-image --version
+
+ENV GRADLE_VERSION 8.4
+ARG GRADLE_DOWNLOAD_SHA256=3e1af3ae886920c3ac87f7a91f816c0c7c436f276a6eefdb3da152100fef72ae
+RUN set -o errexit -o nounset \
+    && echo "Downloading Gradle" \
+    && wget --no-verbose --output-document=gradle.zip "https://services.gradle.org/distributions/gradle-${GRADLE_VERSION}-bin.zip" \
+    \
+    && echo "Checking Gradle download hash" \
+    && echo "${GRADLE_DOWNLOAD_SHA256} *gradle.zip" | sha256sum --check - \
+    \
+    && echo "Installing Gradle" \
+    && unzip gradle.zip \
+    && rm gradle.zip \
+    && mv "gradle-${GRADLE_VERSION}" "${GRADLE_HOME}/" \
+    && ln --symbolic "${GRADLE_HOME}/bin/gradle" /usr/bin/gradle \
+    \
+    && echo "Testing Gradle installation" \
+    && gradle --version \
+    \
+    # chown last so that it applies to /home/gradle/.gradle/native
+    && chown --recursive gradle:gradle /home/gradle

--- a/jdk17and21/Dockerfile
+++ b/jdk17and21/Dockerfile
@@ -1,0 +1,71 @@
+FROM eclipse-temurin:21-jdk-jammy AS java21
+
+FROM eclipse-temurin:17-jdk-jammy
+
+COPY --from=java21 /opt/java/openjdk /opt/java/openjdk21
+RUN set -o errexit -o nounset \
+    && ln --symbolic /opt/java/openjdk17 /opt/java/openjdk
+ENV JAVA17_HOME /opt/java/openjdk17
+ENV JAVA21_HOME /opt/java/openjdk21
+
+CMD ["gradle"]
+
+ENV GRADLE_HOME /opt/gradle
+
+RUN set -o errexit -o nounset \
+    && echo "Adding gradle user and group" \
+    && groupadd --system --gid 1000 gradle \
+    && useradd --system --gid gradle --uid 1000 --shell /bin/bash --create-home gradle \
+    && mkdir /home/gradle/.gradle \
+    && chown --recursive gradle:gradle /home/gradle \
+    \
+    && echo "Symlinking root Gradle cache to gradle Gradle cache" \
+    && ln --symbolic /home/gradle/.gradle /root/.gradle \
+    \
+    && echo "Ensuring Gradle uses Java 21" \
+    && echo "org.gradle.java.installations.auto-detect=false" > /home/gradle/.gradle/gradle.properties \
+    && echo "org.gradle.java.installations.auto-download=false" >> /home/gradle/.gradle/gradle.properties \
+    && echo "org.gradle.java.installations.fromEnv=JAVA21_HOME" >> /home/gradle/.gradle/gradle.properties
+
+VOLUME /home/gradle/.gradle
+
+WORKDIR /home/gradle
+
+RUN set -o errexit -o nounset \
+    && apt-get update \
+    && apt-get install --yes --no-install-recommends \
+        unzip \
+        wget \
+        \
+        bzr \
+        git \
+        git-lfs \
+        mercurial \
+        openssh-client \
+        subversion \
+    && rm --recursive --force /var/lib/apt/lists/* \
+    \
+    && echo "Testing VCSes" \
+    && which bzr \
+    && which git \
+    && which git-lfs \
+    && which hg \
+    && which svn
+
+ENV GRADLE_VERSION 8.4
+ARG GRADLE_DOWNLOAD_SHA256=3e1af3ae886920c3ac87f7a91f816c0c7c436f276a6eefdb3da152100fef72ae
+RUN set -o errexit -o nounset \
+    && echo "Downloading Gradle" \
+    && wget --no-verbose --output-document=gradle.zip "https://services.gradle.org/distributions/gradle-${GRADLE_VERSION}-bin.zip" \
+    \
+    && echo "Checking download hash" \
+    && echo "${GRADLE_DOWNLOAD_SHA256} *gradle.zip" | sha256sum --check - \
+    \
+    && echo "Installing Gradle" \
+    && unzip gradle.zip \
+    && rm gradle.zip \
+    && mv "gradle-${GRADLE_VERSION}" "${GRADLE_HOME}/" \
+    && ln --symbolic "${GRADLE_HOME}/bin/gradle" /usr/bin/gradle \
+    \
+    && echo "Testing Gradle installation" \
+    && gradle --version


### PR DESCRIPTION
Copying ideas from #248 to create an image with both Java 17 and 21 to work around the fact Gradle doesn't support Java 21 yet.

The latest (8.4) [release notes](https://docs.gradle.org/8.4/release-notes.html#java-21) say

> Gradle now supports using Java 21 for compiling, testing, and starting other Java programs. This can be accomplished by configuring your build or task to use a Java 21 [toolchain](https://docs.gradle.org/8.4/userguide/toolchains.html).

> You cannot currently run Gradle on Java 21 because Kotlin lacks support for JDK 21. However, you can expect support for running Gradle with Java 21 in a future version.

They also note this in their [compatibility guide](https://docs.gradle.org/current/userguide/compatibility.html). This is why Java 21 images aren't published to Docker Hub.