### PR TITLE
Replace legacy ENV style

### DIFF
--- a/jdk-lts-and-current-alpine/Dockerfile
+++ b/jdk-lts-and-current-alpine/Dockerfile
@@ -3,12 +3,12 @@ FROM eclipse-temurin:21-jdk-alpine
 COPY --from=eclipse-temurin:23-jdk-alpine /opt/java/openjdk /opt/java/openjdk23
 RUN set -o errexit -o nounset \
     && ln -s /opt/java/openjdk /opt/java/openjdk21
-ENV JAVA_CURRENT_HOME /opt/java/openjdk23
-ENV JAVA_LTS_HOME /opt/java/openjdk21
+ENV JAVA_CURRENT_HOME=/opt/java/openjdk23
+ENV JAVA_LTS_HOME=/opt/java/openjdk21
 
 CMD ["gradle"]
 
-ENV GRADLE_HOME /opt/gradle
+ENV GRADLE_HOME=/opt/gradle
 
 RUN set -o errexit -o nounset \
     && echo "Adding gradle user and group" \
@@ -43,7 +43,7 @@ RUN set -o errexit -o nounset \
     && which hg \
     && which svn
 
-ENV GRADLE_VERSION 8.10.2
+ENV GRADLE_VERSION=8.10.2
 ARG GRADLE_DOWNLOAD_SHA256=31c55713e40233a8303827ceb42ca48a47267a0ad4bab9177123121e71524c26
 RUN set -o errexit -o nounset \
     && echo "Downloading Gradle" \

--- a/jdk-lts-and-current-graal/Dockerfile
+++ b/jdk-lts-and-current-graal/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:jammy
 
 CMD ["gradle"]
 
-ENV GRADLE_HOME /opt/gradle
+ENV GRADLE_HOME=/opt/gradle
 
 RUN set -o errexit -o nounset \
     && echo "Adding gradle user and group" \
@@ -57,8 +57,8 @@ RUN set -o errexit -o nounset \
     && which svn
 
 ENV JAVA_HOME=/opt/java/graalvm
-ENV JAVA_LTS_HOME /opt/java/graalvm21
-ENV JAVA_CURRENT_HOME /opt/java/graalvm23
+ENV JAVA_LTS_HOME=/opt/java/graalvm21
+ENV JAVA_CURRENT_HOME=/opt/java/graalvm23
 RUN set -o errexit -o nounset \
     && mkdir /opt/java \
     \
@@ -115,7 +115,7 @@ RUN set -o errexit -o nounset \
     && javac --version \
     && native-image --version
 
-ENV GRADLE_VERSION 8.10.2
+ENV GRADLE_VERSION=8.10.2
 ARG GRADLE_DOWNLOAD_SHA256=31c55713e40233a8303827ceb42ca48a47267a0ad4bab9177123121e71524c26
 RUN set -o errexit -o nounset \
     && echo "Downloading Gradle" \

--- a/jdk-lts-and-current/Dockerfile
+++ b/jdk-lts-and-current/Dockerfile
@@ -3,12 +3,12 @@ FROM eclipse-temurin:21-jdk-jammy
 COPY --from=eclipse-temurin:23-jdk-noble /opt/java/openjdk /opt/java/openjdk23
 RUN set -o errexit -o nounset \
     && ln --symbolic /opt/java/openjdk /opt/java/openjdk21
-ENV JAVA_LTS_HOME /opt/java/openjdk21
-ENV JAVA_CURRENT_HOME /opt/java/openjdk23
+ENV JAVA_LTS_HOME=/opt/java/openjdk21
+ENV JAVA_CURRENT_HOME=/opt/java/openjdk23
 
 CMD ["gradle"]
 
-ENV GRADLE_HOME /opt/gradle
+ENV GRADLE_HOME=/opt/gradle
 
 RUN set -o errexit -o nounset \
     && echo "Adding gradle user and group" \
@@ -50,7 +50,7 @@ RUN set -o errexit -o nounset \
     && which hg \
     && which svn
 
-ENV GRADLE_VERSION 8.10.2
+ENV GRADLE_VERSION=8.10.2
 ARG GRADLE_DOWNLOAD_SHA256=31c55713e40233a8303827ceb42ca48a47267a0ad4bab9177123121e71524c26
 RUN set -o errexit -o nounset \
     && echo "Downloading Gradle" \

--- a/jdk11-alpine/Dockerfile
+++ b/jdk11-alpine/Dockerfile
@@ -2,7 +2,7 @@ FROM eclipse-temurin:11-jdk-alpine
 
 CMD ["gradle"]
 
-ENV GRADLE_HOME /opt/gradle
+ENV GRADLE_HOME=/opt/gradle
 
 RUN set -o errexit -o nounset \
     && echo "Adding gradle user and group" \
@@ -33,7 +33,7 @@ RUN set -o errexit -o nounset \
     && which hg \
     && which svn
 
-ENV GRADLE_VERSION 8.10.2
+ENV GRADLE_VERSION=8.10.2
 ARG GRADLE_DOWNLOAD_SHA256=31c55713e40233a8303827ceb42ca48a47267a0ad4bab9177123121e71524c26
 RUN set -o errexit -o nounset \
     && echo "Downloading Gradle" \

--- a/jdk11-focal/Dockerfile
+++ b/jdk11-focal/Dockerfile
@@ -2,7 +2,7 @@ FROM eclipse-temurin:11-jdk-focal
 
 CMD ["gradle"]
 
-ENV GRADLE_HOME /opt/gradle
+ENV GRADLE_HOME=/opt/gradle
 
 RUN set -o errexit -o nounset \
     && echo "Adding gradle user and group" \
@@ -40,7 +40,7 @@ RUN set -o errexit -o nounset \
     && which hg \
     && which svn
 
-ENV GRADLE_VERSION 8.10.2
+ENV GRADLE_VERSION=8.10.2
 ARG GRADLE_DOWNLOAD_SHA256=31c55713e40233a8303827ceb42ca48a47267a0ad4bab9177123121e71524c26
 RUN set -o errexit -o nounset \
     && echo "Downloading Gradle" \

--- a/jdk11/Dockerfile
+++ b/jdk11/Dockerfile
@@ -2,7 +2,7 @@ FROM eclipse-temurin:11-jdk-jammy
 
 CMD ["gradle"]
 
-ENV GRADLE_HOME /opt/gradle
+ENV GRADLE_HOME=/opt/gradle
 
 RUN set -o errexit -o nounset \
     && echo "Adding gradle user and group" \
@@ -40,7 +40,7 @@ RUN set -o errexit -o nounset \
     && which hg \
     && which svn
 
-ENV GRADLE_VERSION 8.10.2
+ENV GRADLE_VERSION=8.10.2
 ARG GRADLE_DOWNLOAD_SHA256=31c55713e40233a8303827ceb42ca48a47267a0ad4bab9177123121e71524c26
 RUN set -o errexit -o nounset \
     && echo "Downloading Gradle" \

--- a/jdk17-alpine/Dockerfile
+++ b/jdk17-alpine/Dockerfile
@@ -2,7 +2,7 @@ FROM eclipse-temurin:17-jdk-alpine
 
 CMD ["gradle"]
 
-ENV GRADLE_HOME /opt/gradle
+ENV GRADLE_HOME=/opt/gradle
 
 RUN set -o errexit -o nounset \
     && echo "Adding gradle user and group" \
@@ -33,7 +33,7 @@ RUN set -o errexit -o nounset \
     && which hg \
     && which svn
 
-ENV GRADLE_VERSION 8.10.2
+ENV GRADLE_VERSION=8.10.2
 ARG GRADLE_DOWNLOAD_SHA256=31c55713e40233a8303827ceb42ca48a47267a0ad4bab9177123121e71524c26
 RUN set -o errexit -o nounset \
     && echo "Downloading Gradle" \

--- a/jdk17-focal-graal/Dockerfile
+++ b/jdk17-focal-graal/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:focal
 
 CMD ["gradle"]
 
-ENV GRADLE_HOME /opt/gradle
+ENV GRADLE_HOME=/opt/gradle
 
 RUN set -o errexit -o nounset \
     && echo "Adding gradle user and group" \
@@ -88,7 +88,7 @@ RUN set -o errexit -o nounset \
     && gu --version \
     && native-image --version
 
-ENV GRADLE_VERSION 8.10.2
+ENV GRADLE_VERSION=8.10.2
 ARG GRADLE_DOWNLOAD_SHA256=31c55713e40233a8303827ceb42ca48a47267a0ad4bab9177123121e71524c26
 RUN set -o errexit -o nounset \
     && echo "Downloading Gradle" \

--- a/jdk17-focal/Dockerfile
+++ b/jdk17-focal/Dockerfile
@@ -2,7 +2,7 @@ FROM eclipse-temurin:17-jdk-focal
 
 CMD ["gradle"]
 
-ENV GRADLE_HOME /opt/gradle
+ENV GRADLE_HOME=/opt/gradle
 
 RUN set -o errexit -o nounset \
     && echo "Adding gradle user and group" \
@@ -40,7 +40,7 @@ RUN set -o errexit -o nounset \
     && which hg \
     && which svn
 
-ENV GRADLE_VERSION 8.10.2
+ENV GRADLE_VERSION=8.10.2
 ARG GRADLE_DOWNLOAD_SHA256=31c55713e40233a8303827ceb42ca48a47267a0ad4bab9177123121e71524c26
 RUN set -o errexit -o nounset \
     && echo "Downloading Gradle" \

--- a/jdk17-graal/Dockerfile
+++ b/jdk17-graal/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:jammy
 
 CMD ["gradle"]
 
-ENV GRADLE_HOME /opt/gradle
+ENV GRADLE_HOME=/opt/gradle
 
 RUN set -o errexit -o nounset \
     && echo "Adding gradle user and group" \
@@ -88,7 +88,7 @@ RUN set -o errexit -o nounset \
     && gu --version \
     && native-image --version
 
-ENV GRADLE_VERSION 8.10.2
+ENV GRADLE_VERSION=8.10.2
 ARG GRADLE_DOWNLOAD_SHA256=31c55713e40233a8303827ceb42ca48a47267a0ad4bab9177123121e71524c26
 RUN set -o errexit -o nounset \
     && echo "Downloading Gradle" \

--- a/jdk17/Dockerfile
+++ b/jdk17/Dockerfile
@@ -2,7 +2,7 @@ FROM eclipse-temurin:17-jdk-jammy
 
 CMD ["gradle"]
 
-ENV GRADLE_HOME /opt/gradle
+ENV GRADLE_HOME=/opt/gradle
 
 RUN set -o errexit -o nounset \
     && echo "Adding gradle user and group" \
@@ -39,7 +39,7 @@ RUN set -o errexit -o nounset \
     && which hg \
     && which svn
 
-ENV GRADLE_VERSION 8.10.2
+ENV GRADLE_VERSION=8.10.2
 ARG GRADLE_DOWNLOAD_SHA256=31c55713e40233a8303827ceb42ca48a47267a0ad4bab9177123121e71524c26
 RUN set -o errexit -o nounset \
     && echo "Downloading Gradle" \

--- a/jdk21-alpine/Dockerfile
+++ b/jdk21-alpine/Dockerfile
@@ -2,7 +2,7 @@ FROM eclipse-temurin:21-jdk-alpine
 
 CMD ["gradle"]
 
-ENV GRADLE_HOME /opt/gradle
+ENV GRADLE_HOME=/opt/gradle
 
 RUN set -o errexit -o nounset \
     && echo "Adding gradle user and group" \
@@ -33,7 +33,7 @@ RUN set -o errexit -o nounset \
     && which hg \
     && which svn
 
-ENV GRADLE_VERSION 8.10.2
+ENV GRADLE_VERSION=8.10.2
 ARG GRADLE_DOWNLOAD_SHA256=31c55713e40233a8303827ceb42ca48a47267a0ad4bab9177123121e71524c26
 RUN set -o errexit -o nounset \
     && echo "Downloading Gradle" \

--- a/jdk21-graal/Dockerfile
+++ b/jdk21-graal/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:jammy
 
 CMD ["gradle"]
 
-ENV GRADLE_HOME /opt/gradle
+ENV GRADLE_HOME=/opt/gradle
 
 RUN set -o errexit -o nounset \
     && echo "Adding gradle user and group" \
@@ -87,7 +87,7 @@ RUN set -o errexit -o nounset \
     && javac --version \
     && native-image --version
 
-ENV GRADLE_VERSION 8.10.2
+ENV GRADLE_VERSION=8.10.2
 ARG GRADLE_DOWNLOAD_SHA256=31c55713e40233a8303827ceb42ca48a47267a0ad4bab9177123121e71524c26
 RUN set -o errexit -o nounset \
     && echo "Downloading Gradle" \

--- a/jdk21/Dockerfile
+++ b/jdk21/Dockerfile
@@ -2,7 +2,7 @@ FROM eclipse-temurin:21-jdk-jammy
 
 CMD ["gradle"]
 
-ENV GRADLE_HOME /opt/gradle
+ENV GRADLE_HOME=/opt/gradle
 
 RUN set -o errexit -o nounset \
     && echo "Adding gradle user and group" \
@@ -40,7 +40,7 @@ RUN set -o errexit -o nounset \
     && which hg \
     && which svn
 
-ENV GRADLE_VERSION 8.10.2
+ENV GRADLE_VERSION=8.10.2
 ARG GRADLE_DOWNLOAD_SHA256=31c55713e40233a8303827ceb42ca48a47267a0ad4bab9177123121e71524c26
 RUN set -o errexit -o nounset \
     && echo "Downloading Gradle" \

--- a/jdk23-alpine/Dockerfile
+++ b/jdk23-alpine/Dockerfile
@@ -2,7 +2,7 @@ FROM eclipse-temurin:23-jdk-alpine
 
 CMD ["gradle"]
 
-ENV GRADLE_HOME /opt/gradle
+ENV GRADLE_HOME=/opt/gradle
 
 RUN set -o errexit -o nounset \
     && echo "Adding gradle user and group" \
@@ -33,7 +33,7 @@ RUN set -o errexit -o nounset \
     && which hg \
     && which svn
 
-ENV GRADLE_VERSION 8.10.2
+ENV GRADLE_VERSION=8.10.2
 ARG GRADLE_DOWNLOAD_SHA256=31c55713e40233a8303827ceb42ca48a47267a0ad4bab9177123121e71524c26
 RUN set -o errexit -o nounset \
     && echo "Downloading Gradle" \

--- a/jdk23-graal/Dockerfile
+++ b/jdk23-graal/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:jammy
 
 CMD ["gradle"]
 
-ENV GRADLE_HOME /opt/gradle
+ENV GRADLE_HOME=/opt/gradle
 
 RUN set -o errexit -o nounset \
     && echo "Adding gradle user and group" \
@@ -87,7 +87,7 @@ RUN set -o errexit -o nounset \
     && javac --version \
     && native-image --version
 
-ENV GRADLE_VERSION 8.10.2
+ENV GRADLE_VERSION=8.10.2
 ARG GRADLE_DOWNLOAD_SHA256=31c55713e40233a8303827ceb42ca48a47267a0ad4bab9177123121e71524c26
 RUN set -o errexit -o nounset \
     && echo "Downloading Gradle" \

--- a/jdk23/Dockerfile
+++ b/jdk23/Dockerfile
@@ -2,7 +2,7 @@ FROM eclipse-temurin:23-jdk-noble
 
 CMD ["gradle"]
 
-ENV GRADLE_HOME /opt/gradle
+ENV GRADLE_HOME=/opt/gradle
 
 RUN set -o errexit -o nounset \
     && echo "Adding gradle user and group" \
@@ -40,7 +40,7 @@ RUN set -o errexit -o nounset \
     && which hg \
     && which svn
 
-ENV GRADLE_VERSION 8.10.2
+ENV GRADLE_VERSION=8.10.2
 ARG GRADLE_DOWNLOAD_SHA256=31c55713e40233a8303827ceb42ca48a47267a0ad4bab9177123121e71524c26
 RUN set -o errexit -o nounset \
     && echo "Downloading Gradle" \

--- a/jdk8-focal/Dockerfile
+++ b/jdk8-focal/Dockerfile
@@ -2,7 +2,7 @@ FROM eclipse-temurin:8-jdk-focal
 
 CMD ["gradle"]
 
-ENV GRADLE_HOME /opt/gradle
+ENV GRADLE_HOME=/opt/gradle
 
 RUN set -o errexit -o nounset \
     && echo "Adding gradle user and group" \
@@ -40,7 +40,7 @@ RUN set -o errexit -o nounset \
     && which hg \
     && which svn
 
-ENV GRADLE_VERSION 8.10.2
+ENV GRADLE_VERSION=8.10.2
 ARG GRADLE_DOWNLOAD_SHA256=31c55713e40233a8303827ceb42ca48a47267a0ad4bab9177123121e71524c26
 RUN set -o errexit -o nounset \
     && echo "Downloading Gradle" \

--- a/jdk8/Dockerfile
+++ b/jdk8/Dockerfile
@@ -2,7 +2,7 @@ FROM eclipse-temurin:8-jdk-jammy
 
 CMD ["gradle"]
 
-ENV GRADLE_HOME /opt/gradle
+ENV GRADLE_HOME=/opt/gradle
 
 RUN set -o errexit -o nounset \
     && echo "Adding gradle user and group" \
@@ -40,7 +40,7 @@ RUN set -o errexit -o nounset \
     && which hg \
     && which svn
 
-ENV GRADLE_VERSION 8.10.2
+ENV GRADLE_VERSION=8.10.2
 ARG GRADLE_DOWNLOAD_SHA256=31c55713e40233a8303827ceb42ca48a47267a0ad4bab9177123121e71524c26
 RUN set -o errexit -o nounset \
     && echo "Downloading Gradle" \


### PR DESCRIPTION
Fixes violations of this build check: https://docs.docker.com/reference/build-checks/legacy-key-value-format/